### PR TITLE
Updated user icon to use default when one isn't specified

### DIFF
--- a/lib/omniauth/strategies/flickr.rb
+++ b/lib/omniauth/strategies/flickr.rb
@@ -62,8 +62,10 @@ module OmniAuth
       end
 
       def image_info
-        if user_info["iconfarm"] > 0
+        if user_info["iconfarm"] && user_info["iconfarm"] > 0
           "http://farm#{user_info["iconfarm"]}.static.flickr.com/#{user_info["iconserver"]}/buddyicons/#{uid}.jpg"
+        else
+          "http://www.flickr.com/images/buddyicon.gif"
         end
       end
 


### PR DESCRIPTION
## What is this?

This sets a default icon if one doesn't exist for the user.  Per http://www.flickr.com/services/api/misc.buddyicons.html, http://www.flickr.com/images/buddyicon.gif should be used for the icon if the icon server isn't greater than zero.

For this case `user_info["iconfarm"]` was returning `nil` causing `NoMethodError: undefined method '>' for nil:NilClass`.
