### PR TITLE
Change places of name and nickname. Fixes #12

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ Example [AuthHash](https://github.com/intridea/omniauth/wiki/Auth-Hash-Schema) f
 provider: flickr
 uid: 62839091@N05
 info: !ruby/hash:OmniAuth::AuthHash::InfoHash
-  name: example_user
-  nickname: Example User
+  name: Example User
+  nickname: example_user
   ispro: 0
   iconserver: '8061'
   iconfarm: 9

--- a/lib/omniauth/strategies/flickr.rb
+++ b/lib/omniauth/strategies/flickr.rb
@@ -23,8 +23,8 @@ module OmniAuth
 
       info do
         {
-          :name => access_token.params['username'],
-          :nickname => access_token.params['fullname'],
+          :name => access_token.params['fullname'],
+          :nickname => access_token.params['username'],
           :ispro => user_info["ispro"],
           :iconserver => user_info["iconserver"],
           :iconfarm => user_info["iconfarm"],


### PR DESCRIPTION
* `name` (required) - The best display name known to the strategy. Usually a concatenation of first and last name, but may also be an arbitrary designator or nickname for some strategies
* `nickname` - The username of an authenticating user (such as your @-name from Twitter or GitHub account name)

https://github.com/intridea/omniauth/wiki/Auth-Hash-Schema/